### PR TITLE
Replacing the keyword "assert" with "with"

### DIFF
--- a/page.js
+++ b/page.js
@@ -1,4 +1,4 @@
-import data from './properties.json' assert {type: 'json'};
+import data from './properties.json' with {type: 'json'};
 
 console.log(data)
 data.innerText = JSON.stringify(data, null, 2);


### PR DESCRIPTION
Replacing the keyword "assert" with "with" due to support for "import assertions" being removed from Node in favour of "import attributes"